### PR TITLE
Add pointer-events: none to thumbnail for loaded modal

### DIFF
--- a/assets/css/gallerydeluxe/styles.css
+++ b/assets/css/gallerydeluxe/styles.css
@@ -56,6 +56,7 @@
 
 .gd-modal-content.gd-modal-loaded.gd-modal-thumbnail {
   opacity: 0;
+  pointer-events: none;
 }
 
 .gd-modal-exif {


### PR DESCRIPTION
This makes right clicking an opened image (not the thumbnail) possible.

Closes #15